### PR TITLE
changed to scroll to accomodate if scroll needed when showing an element

### DIFF
--- a/app/javascript/stylesheets/config/_animations.scss
+++ b/app/javascript/stylesheets/config/_animations.scss
@@ -43,14 +43,14 @@
     max-height: 150px;
     transform: scale(1);
     opacity: 1;
-    overflow: hidden;
+    overflow: scroll;
   }
 
   to {
     max-height: 0px;
     transform: scale(0);
     opacity: 0;
-    overflow: hidden;
+    overflow: scroll;
     padding: 0px;
     display: none;
   }
@@ -66,14 +66,14 @@
     max-height: 0px;
     transform: scale(0);
     opacity: 0;
-    overflow: hidden;
+    overflow: scroll;
   }
 
   to {
     max-height: 200px;
     transform: scale(1);
     opacity: 1;
-    overflow: hidden;
+    overflow: scroll;
   }
 }
 


### PR DESCRIPTION
This could possibly bite us, but I make elements overflow scroll when we hide them. This sounds weird, but they're max-height: 0px when we hide them, so the scroll won't work.